### PR TITLE
USE_EXTENSION_FUNCTIONS 有効化（リマインダー・メモ機能）

### DIFF
--- a/firmware/src/llm/ChatGPT/FunctionCall.cpp
+++ b/firmware/src/llm/ChatGPT/FunctionCall.cpp
@@ -24,6 +24,9 @@ extern void sw_tone();
 
 static String avatarText;
 
+// Notepad content for save_note/read_note/delete_note
+String note = "";
+
 // タイマー機能関連
 TimerHandle_t xAlarmTimer;
 bool alarmTimerCallbacked = false;
@@ -178,6 +181,36 @@ const String json_Functions =
       "}"
     "}"
   "},"
+  "{"
+    "\"name\": \"save_note\","
+    "\"description\": \"メモを保存する。買い物リストやTODOなど。\","
+    "\"parameters\": {"
+      "\"type\":\"object\","
+      "\"properties\": {"
+        "\"text\":{"
+          "\"type\": \"string\","
+          "\"description\": \"メモの内容\""
+        "}"
+      "},"
+      "\"required\": [\"text\"]"
+    "}"
+  "},"
+  "{"
+    "\"name\": \"read_note\","
+    "\"description\": \"保存されているメモを読み上げる。\","
+    "\"parameters\": {"
+      "\"type\":\"object\","
+      "\"properties\": {}"
+    "}"
+  "},"
+  "{"
+    "\"name\": \"delete_note\","
+    "\"description\": \"保存されているメモを消去する。\","
+    "\"parameters\": {"
+      "\"type\":\"object\","
+      "\"properties\": {}"
+    "}"
+  "}"
 #endif //if defined(USE_EXTENSION_FUNCTIONS)
 "]";
 
@@ -294,6 +327,16 @@ String FunctionCall::exec_calledFunc(const char* name, const char* args){
       const char* text = argsDoc["text"];
       Serial.println(text);
       response = ask(text);
+    }
+    else if(strcmp(name, "save_note") == 0){
+      const char* text = argsDoc["text"];
+      response = save_note(text);
+    }
+    else if(strcmp(name, "read_note") == 0){
+      response = read_note();
+    }
+    else if(strcmp(name, "delete_note") == 0){
+      response = delete_note();
     }
 #endif  //if defined(USE_EXTENSION_FUNCTIONS)
 
@@ -655,8 +698,9 @@ String FunctionCall::get_bus_time(int nNext){
 }
 
 
-//メッセージをメールで送信する関数
-// ※EMailSenderライブラリのインクルード、及びplatformio.iniのlib_depsでの宣言を有効化してください。
+// TODO: send_mail requires EMailSender library and mail config — excluded for now
+// See GitHub Issue #13 (Gmail連携) for future implementation
+#if 0
 String FunctionCall::send_mail(String msg) {
   String response = "";
   EMailSender::EMailMessage message;
@@ -684,8 +728,11 @@ String FunctionCall::send_mail(String msg) {
 
   return response;
 }
+#endif
 
-//受信したメールを読み上げる
+// TODO: read_mail requires mail receiver setup — excluded for now
+// See GitHub Issue #13 (Gmail連携) for future implementation
+#if 0
 String FunctionCall::read_mail(void) {
   String response = "";
 
@@ -697,9 +744,10 @@ String FunctionCall::read_mail(void) {
   else{
     response = "受信メールはありません。";
   }
-  
+
   return response;
 }
+#endif
 
 
 #endif  //if defined(USE_EXTENSION_FUNCTIONS)

--- a/firmware/src/llm/ChatGPT/FunctionCall.h
+++ b/firmware/src/llm/ChatGPT/FunctionCall.h
@@ -7,7 +7,7 @@
 #include "MCPClient.h"
 #include "llm/LLMBase.h"
 
-//#define USE_EXTENSION_FUNCTIONS
+#define USE_EXTENSION_FUNCTIONS
 
 #define APP_DATA_PATH   "/app/AiStackChanEx/"
 #define FNAME_NOTEPAD   "notepad.txt"
@@ -61,6 +61,11 @@ public:
     #if defined(USE_EXTENSION_FUNCTIONS)
     String reminder(int hour, int min, const char* text);
     String ask(const char* text);
+    String save_note(const char* text);
+    String read_note();
+    String delete_note();
+    String get_bus_time(int nNext);
+    // send_mail / read_mail are excluded until EMailSender library is configured
     #endif  //USE_EXTENSION_FUNCTIONS
 };
 


### PR DESCRIPTION
## Description

- `USE_EXTENSION_FUNCTIONS` ビルドフラグを有効化
- `save_note`/`read_note`/`delete_note` をJSON関数定義 + exec_calledFunc に登録し、LLMから呼び出し可能にした
- `send_mail`/`read_mail` は EMailSender ライブラリ未設定のため `#if 0` で除外（#13 Gmail連携で対応予定）
- `note` 変数の実体定義を追加（リンクエラー修正）

## Related Issues

Closes #5

## Test Plan

- [x] CoreS3 向けビルド成功（RAM 20.8%, Flash 38.0%）
- [ ] SDカード + APIキー設定後に実機テスト（「メモして」「メモ読んで」「3時にリマインドして」）

## Review Checklist

- [x] Memory usage checked (heap/PSRAM within budget)
- [x] No secrets committed (API keys, Wi-Fi passwords)
- [ ] Tested on CoreS3 hardware (build-only, no device test yet)
- [x] Existing features not broken

## Breaking Changes

None